### PR TITLE
fixed possible version and comment metadata leaks

### DIFF
--- a/autocanary/gnupg.py
+++ b/autocanary/gnupg.py
@@ -77,7 +77,7 @@ class GnuPG(object):
         open(filename, 'w').write(text)
 
         # sign the file
-        p = subprocess.Popen(self.gpg_command + ['--use-agent', '--default-key', signing_fp, '--clearsign', '--no-emit-version', '--no-comments', filename], creationflags=self.creationflags)
+        p = subprocess.Popen(self.gpg_command + ['--use-agent', '--default-key', signing_fp, '--no-emit-version', '--no-comments', '--clearsign', filename], creationflags=self.creationflags)
         returncode = p.wait()
         if returncode != 0:
             shutil.rmtree(tempdir)

--- a/autocanary/gnupg.py
+++ b/autocanary/gnupg.py
@@ -77,7 +77,7 @@ class GnuPG(object):
         open(filename, 'w').write(text)
 
         # sign the file
-        p = subprocess.Popen(self.gpg_command + ['--use-agent', '--default-key', signing_fp, '--clearsign', filename], creationflags=self.creationflags)
+        p = subprocess.Popen(self.gpg_command + ['--use-agent', '--default-key', signing_fp, '--clearsign', '--no-emit-version', '--no-comments', filename], creationflags=self.creationflags)
         returncode = p.wait()
         if returncode != 0:
             shutil.rmtree(tempdir)


### PR DESCRIPTION
depending on your version of GnuPG and your 'gpg.conf' configuration file, this will help prevent any leaks of your version string (e.g. "Version: GnuPG v2.x.x") or comment (e.g. "GPGTools: http://gpgtools.org"). without a fix, these can possibly be used to exploit any vulnerabilities in certain versions of software.

although there is virtually no attack surface with the copy and paste of clearsigned text, the leakage of the version string may be used with attacks on different applications using GnuPG.
