### PR TITLE
Add button to add headlines from wikinews RSS feed

### DIFF
--- a/autocanary/autocanary.py
+++ b/autocanary/autocanary.py
@@ -21,6 +21,7 @@ from gnupg import GnuPG
 from settings import Settings
 from output_dialog import OutputDialog
 import common
+import feedparser
 
 class AutoCanaryGui(QtGui.QWidget):
 
@@ -129,6 +130,11 @@ class AutoCanaryGui(QtGui.QWidget):
         self.textbox = QtGui.QTextEdit()
         self.textbox.setText(self.settings.get_text())
 
+
+        # add headlines
+        self.add_headlines_button = QtGui.QPushButton('Add Recent News Headlines')
+        self.add_headlines_button.clicked.connect(self.add_headlines)
+
         # key selection
         seckeys = gpg.seckeys_list()
         self.key_selection = QtGui.QComboBox()
@@ -147,7 +153,7 @@ class AutoCanaryGui(QtGui.QWidget):
                     key_i = i
             self.key_selection.setCurrentIndex(key_i)
 
-        # buttons
+        # bottom buttons
         self.buttons_layout = QtGui.QHBoxLayout()
         self.sign_save_button = QtGui.QPushButton('Save and Sign')
         self.sign_save_button.clicked.connect(self.sign_save_clicked)
@@ -161,6 +167,7 @@ class AutoCanaryGui(QtGui.QWidget):
         self.layout.addLayout(self.date_layout)
         self.layout.addLayout(self.status_layout)
         self.layout.addWidget(self.textbox)
+        self.layout.addWidget(self.add_headlines_button)
         self.layout.addWidget(self.key_selection)
         self.layout.addLayout(self.buttons_layout)
         self.setLayout(self.layout)
@@ -345,6 +352,11 @@ class AutoCanaryGui(QtGui.QWidget):
             dialog.exec_()
         else:
             common.alert('Failed to sign message.')
+    def add_headlines(self):
+        feed = feedparser.parse('https://en.wikinews.org/w/index.php?title=Special:NewsFeed&feed=rss&categories=Published&notcategories=No%20publish|Archived|AutoArchived|disputed&namespace=0&count=5&ordermethod=categoryadd&stablepages=only')
+        self.textbox.append('\nRECENT HEADLINES:\n')
+        for entry in feed.entries:
+            self.textbox.append("- " + entry.title)
 
 def main():
     # start the app


### PR DESCRIPTION
Fufills #4.

Before button is clicked (with screen enlarged):
![screen shot 2015-05-29 at 15 42 44](https://cloud.githubusercontent.com/assets/632942/7891416/7c6e6bca-061a-11e5-84ed-161dbdc7af76.png)

After the button is clicked and headlines are added:
![screen shot 2015-05-29 at 15 42 50](https://cloud.githubusercontent.com/assets/632942/7891415/7c5dd8b4-061a-11e5-96a7-5276726575a7.png)

Some thoughts:
- It takes a while to load the feed. Should something like [QProgressIndicator](http://qt-apps.org/content/show.php/?content=115762) be added, while it's loading them?
- Should the feed URL be added to `settings.py`? The `number` of headlines to fetch could also be added there.
- Should the window be larger? Its default size cannot accommodate the default text + headlines
- If someone does 'save & sign', it'll save the old headlines. Should the headlines be removed before saving the text?
- The functionality could come into effect right before signing, but it makes sense to allow the users to edit them before signing.
