### PR TITLE
Fix utf8 encoding/decoding issues, in both text and filenames

### DIFF
--- a/autocanary/autocanary.py
+++ b/autocanary/autocanary.py
@@ -250,12 +250,15 @@ class AutoCanaryGui(QtGui.QWidget):
             self.semiannually_q34.hide()
 
         # update freqency text
-        self.quarterly_q1.setText('Q1 {}'.format(year));
-        self.quarterly_q2.setText('Q2 {}'.format(year));
-        self.quarterly_q3.setText('Q3 {}'.format(year));
-        self.quarterly_q4.setText('Q4 {}'.format(year));
-        self.semiannually_q12.setText('Q1 and Q2 {}'.format(year))
-        self.semiannually_q34.setText('Q3 and Q4 {}'.format(year))
+
+        # the QString objects which represent the widget state are unicode
+        # strings, hence the u'...'
+        self.quarterly_q1.setText(u'Q1 {}'.format(year));
+        self.quarterly_q2.setText(u'Q2 {}'.format(year));
+        self.quarterly_q3.setText(u'Q3 {}'.format(year));
+        self.quarterly_q4.setText(u'Q4 {}'.format(year));
+        self.semiannually_q12.setText(u'Q1 and Q2 {}'.format(year))
+        self.semiannually_q34.setText(u'Q3 and Q4 {}'.format(year))
 
     def get_year_period(self):
         frequency = self.frequency.currentText()
@@ -332,7 +335,10 @@ class AutoCanaryGui(QtGui.QWidget):
                 period_date = 'January 1 to June 30'
             elif year_period == 'Q34':
                 period_date = 'July 1 to December 31'
-        message = 'Status: {}\nPeriod: {}, {}\n\n{}'.format(status, period_date, year, text)
+
+        # the QString objects which represent the widget state are unicode
+        # strings, hence the u'...'
+        message = u'Status: {}\nPeriod: {}, {}\n\n{}'.format(status, period_date, year, text)
 
         # sign the file
         key_i = self.key_selection.currentIndex()

--- a/autocanary/gnupg.py
+++ b/autocanary/gnupg.py
@@ -15,7 +15,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
-import subprocess, os, platform, tempfile, shutil
+import subprocess, os, platform, tempfile, shutil, codecs
 
 class GnuPG(object):
 
@@ -76,7 +76,9 @@ class GnuPG(object):
 
         # write message to file
         filename = '{0}/message'.format(tempdir)
-        open(filename, 'w').write(text)
+
+        # text is a character string: don't forget to encode before writing.
+        open(filename, 'w').write(text.encode('utf-8'))
 
         # sign the file
         p = subprocess.Popen(self.gpg_command + ['--use-agent', '--default-key', signing_fp, '--no-emit-version', '--no-comments', '--clearsign', filename], creationflags=self.creationflags)
@@ -87,7 +89,7 @@ class GnuPG(object):
 
         # read the signed message
         signed_filename = '{0}/message.asc'.format(tempdir)
-        signed_message = open(signed_filename, 'r').read()
+        signed_message = codecs.open(signed_filename, 'r', 'utf-8').read()
         shutil.rmtree(tempdir)
 
         return signed_message

--- a/autocanary/output_dialog.py
+++ b/autocanary/output_dialog.py
@@ -22,6 +22,7 @@ import common
 
 class OutputDialog(QtGui.QDialog):
 
+    # signed_message is a character string.
     def __init__(self, app, signed_message):
         super(OutputDialog, self).__init__()
         self.app = app
@@ -60,15 +61,18 @@ class OutputDialog(QtGui.QDialog):
         d.setDefaultSuffix('asc')
         d.setNameFilter('*.asc')
         if d.exec_():
+            # this is a QString (character string).
             filename = d.selectedFiles()[0]
 
-            # save output to file
+            filename_encoded = u'{}'.format(filename)
+
+            # save output to file; don't forget to encode.
             try:
-                open(filename, 'w').write(self.signed_message)
-                common.alert('Digitally signed cannary message saved to:\n{0}'.format(filename))
+                open(filename_encoded, 'w').write(self.signed_message.encode('utf-8'))
+                common.alert(u'Digitally signed canary message saved to:\n{0}'.format(filename_encoded))
                 self.accept()
             except:
-                common.alert('Failed saving file:\n{0}'.format(filename))
+                common.alert(u'Failed saving file:\n{0}'.format(filename_encoded))
 
     def copy_to_clipboard_clicked(self):
         if platform.system() == 'Windows':


### PR DESCRIPTION
Hi, I believes this fixes #9. As an added bonus you can now also use non-ascii filenames.

You can test with text such as:

```
‘text in curly quotes’

a few ellipses  … …

and some Ancient Greek: ζεγέριες -ων, οἱ 
```
