### PR TITLE
Add button to add headlines from wikinews RSS feed (take 2)

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -10,7 +10,7 @@ The first time you're setting up your dev environment:
 
 ```sh
 brew install qt4 pyqt
-sudo pip install py2app
+sudo pip install py2app feedparser
 ```
 
 To run locally:
@@ -78,7 +78,7 @@ A NSIS window will pop up, and once it's done you will have `dist\AutoCanary_Set
 Install the dependencies:
 
 ```sh
-sudo apt-get install -y build-essential fakeroot python-all python-stdeb python-qt4 gnupg2
+sudo apt-get install -y build-essential fakeroot python-all python-stdeb python-qt4 gnupg2 python-feedparser
 ```
 
 To run locally:
@@ -99,7 +99,7 @@ sudo dpkg -i deb_dist/autocanary_*.deb
 Install the dependencies:
 
 ```sh
-sudo yum install rpm-build pyqt4 gnupg2
+sudo yum install rpm-build pyqt4 gnupg2 python-feedparser
 ```
 
 To run locally:

--- a/autocanary/headlines.py
+++ b/autocanary/headlines.py
@@ -1,0 +1,51 @@
+"""
+AutoCanary | https://firstlook.org/code/autocanary
+Copyright (c) 2015 First Look Media
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+import common
+import feedparser
+
+config = {
+    'feed_url': 'https://en.wikinews.org/w/index.php?title=Special:NewsFeed&feed=rss&categories=Published&notcategories=No%20publish|Archived|AutoArchived|disputed&namespace=0&count=5&ordermethod=categoryadd&stablepages=only',
+    # --- waiting for unicode fix.
+    #'headline_bullet': u"\u2022"
+    'headline_bullet': '> '
+}
+
+class Headlines(object):
+    def __init__(self):
+        self.enabled = False
+        self.have_headlines = False
+        self.headlines_str = None
+
+    def fetch_headlines(self):
+        # --- feed.entries is empty list on fail.
+        feed = feedparser.parse(config['feed_url'])
+
+        # --- available keys: summary_detail published_parsed links title
+        # comments summary guidislink title_detail link published id
+        entry_data = map (lambda x: (x.title,), feed.entries)
+        headlines = map(lambda x: "{}{}".format(config['headline_bullet'], x[0]), entry_data)
+        if len(headlines) == 0:
+            self.have_headlines = False
+            common.alert("Couldn't fetch headlines.")
+        else:
+            self.have_headlines = True
+            self.store_headlines(headlines)
+
+    def store_headlines(self, headlines):
+        self.headlines_str = '\n'.join(headlines)


### PR DESCRIPTION
Hi,

I took the beginning that @cllns made ( #12 ) and expanded on it (but branched off of master).

I did _not_ update the windows instructions -- a pip install should be sufficient (`pip install feedparser`) but since I didn't see any other pip commands in the windows parts I didn't update it.

I also haven't tested on anything but Linux.

I used a pretty simple system for disabling buttons while the feed is loading.

Should you decide to merge this and/or my other pull request ( #15 ), a manual merge will be required.

Hope this helps!
