### PR TITLE
Change gpg4win.org link to HTTPS

### DIFF
--- a/autocanary/__init__.py
+++ b/autocanary/__init__.py
@@ -449,7 +449,7 @@ def main():
 
     elif system == 'Windows':
         if not gpg.is_gpg_available():
-            common.alert('GPG doesn\'t seem to be installed. Install <a href="http://gpg4win.org/">Gpg4win</a>, generate a key, and run AutoCanary again.')
+            common.alert('GPG doesn\'t seem to be installed. Install <a href="https://gpg4win.org/">Gpg4win</a>, generate a key, and run AutoCanary again.')
             sys.exit(0)
 
         seckeys = gpg.seckeys_list()


### PR DESCRIPTION
This pull request fixes issue #27

---

Previously, if GPG wasn't installed on Windows, AutoCanary would throw an error message prompting the user to install [`gpg4win`](https://gpg4win.org). It provided an HTTP hyperlink to `gpg4win`'s [website](https://gpg4win.org).

---

<img width="159" alt="screen shot 2018-02-08 at 6 08 50 pm" src="https://user-images.githubusercontent.com/3037552/36003259-2bfb18c4-0cfb-11e8-8259-c6ab1bffa32f.png">

_A screenshot of the address bar at `https://gpg4win.org`._

---

I have confirmed that `gpg4win`'s website works via https (in fact, http requests just redirect to https), and this pull request changes the link accordingly.

Thanks!